### PR TITLE
Issue 95: fix convention for entry names in multi-scan NeXus files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2023-12-15 Jan Kotanski <jankotan@gmail.com>
+	* fix convention for entry names in multi-scan NeXus files (#96)
+	* tagged as 3.18.1
+
+2023-12-15 Jan Kotanski <jankotan@gmail.com>
 	* add support for fetching metadata from multi-scan NeXus files (#90)
 	* add support for SciCatAutoGrouping flag (#92)
 	* tagged as 3.18.0

--- a/sardananxsrecorder/__init__.py
+++ b/sardananxsrecorder/__init__.py
@@ -20,4 +20,4 @@
 """ Sardana Scan Recorders """
 
 #: package version
-__version__ = "3.18.0"
+__version__ = "3.18.1"

--- a/sardananxsrecorder/nxsrecorder.py
+++ b/sardananxsrecorder/nxsrecorder.py
@@ -1201,7 +1201,7 @@ class NXS_FileRecorder(BaseFileRecorder):
 
         if appendentry is True:
             sid = self.__getEnvVar("ScanID", 0)
-            sname = "%s::/%s%05i;%s_%05i" % (
+            sname = "%s::/%s%i;%s_%05i" % (
                 scanname, entryname, sid, scanname, sid)
 
         # auto grouping


### PR DESCRIPTION
It resolves #95 by fixing convention  for entry names in multi-scan NeXus files