### PR TITLE
Issue 111: replace deprecated tz.localize() with datetime.replace()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-05-23 Jan Kotanski <jankotan@gmail.com>
+	* replace deprecated tz.localize() with datetime.replace() (#111)
+	* tagged as 3.21.1
+
 2024-05-22 Jan Kotanski <jankotan@gmail.com>
 	* improve support for creating measurement files in appendentry mode (#108)
 	* change entryname in the appendentry mode to '%s_%05i' (#108)

--- a/sardananxsrecorder/__init__.py
+++ b/sardananxsrecorder/__init__.py
@@ -20,4 +20,4 @@
 """ Sardana Scan Recorders """
 
 #: package version
-__version__ = "3.21.0"
+__version__ = "3.21.1"

--- a/sardananxsrecorder/nxsrecorder.py
+++ b/sardananxsrecorder/nxsrecorder.py
@@ -22,6 +22,7 @@
 
 import os
 import re
+import sys
 
 import numpy
 import json
@@ -1129,7 +1130,10 @@ class NXS_FileRecorder(BaseFileRecorder):
             tz = pytz.timezone(self.__timezone)
 
         fmt = '%Y-%m-%dT%H:%M:%S.%f%z'
-        starttime = tz.localize(mtime)
+        if sys.version_info > (3, 6):
+            starttime = mtime.replace(tzinfo=tz)
+        else:
+            starttime = tz.localize(mtime)
         return str(starttime.strftime(fmt))
 
     def _endRecordList(self, recordlist):


### PR DESCRIPTION
It resolves #111